### PR TITLE
Add try/except to account for line wrap

### DIFF
--- a/linux_metrics/disk_stat.py
+++ b/linux_metrics/disk_stat.py
@@ -31,7 +31,6 @@
 
 
 import time
-import os
 from subprocess import Popen, PIPE
 
    
@@ -80,8 +79,13 @@ def disk_reads_writes(device):
 def disk_usage(path):
     """Return disk usage statistics about the given path."""    	
     output = Popen(['df', '-k', path], stdout=PIPE).communicate()[0]
-    df = output.splitlines()[1].split()
-    (device, size, used, free, percent, mountpoint) = df
+    try:
+        df = output.splitlines()[2].split()
+        device = output.splitlines()[1]
+        (size, used, free, percent, mountpoint) = df
+    except IndexError:
+        df = output.splitlines()[1].split()
+        (device, size, used, free, percent, mountpoint) = df
     return (device, int(size), int(used), int(free), percent, mountpoint)
 
 


### PR DESCRIPTION
On some linux systems the call from df -k (mount) is wrapped and has
3 lines, and on (most) systems 2 lines are there. This change accounts
for both of these situations by trying the 3 line and failing over to
the 2 line response handling from df.